### PR TITLE
暴力解决上传文件时存在重复的文件无法继续上传的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var DEFAULTS = {
   prefix: ''
 };
 
-exports.upload = function(options) {
+exports.upload = function (options) {
   options = assign({}, DEFAULTS, options);
 
   var client = QN.create(options.qn);
@@ -26,13 +26,12 @@ exports.upload = function(options) {
     throw new PluginError(PLUGIN_NAME, 'Missing Qiniu dn configs!');
   }
 
-
   // TODO: 根据文件 hash 判断文件是否改变，只上传改变的文件
   // http://kb.qiniu.com/53tubk96
   // https://github.com/demohi/gulp-qn/blob/master/lib/qn.js#L40
 
   // http://artandlogic.com/2014/05/a-simple-gulp-plugin/
-  return map(function(file, callback) {
+  return map(function (file, callback) {
     if (file.isNull()) {
       callback(null, file);
       return;
@@ -40,9 +39,27 @@ exports.upload = function(options) {
 
     var fileKey = path.join(options.prefix, options.flatten ?
       path.basename(file.path) : file.relative);
+    
+    //如果slashReverse为true，则路径中的将反斜杠转为斜杠
+    if (options.qn.slashReverse) {
+      var re = new RegExp('\\\\', 'g');
+      fileKey = fileKey.replace(re, "/");  
+    }
+    
+    //如果delete为true则先删除原来的文件再进行上传
+    if (options.qn.delete) {
+      client.delete(fileKey, function (err, result) { 
+        log(fileKey);
+        if (err) { 
+          log('Error', colors.red(new PluginError(PLUGIN_NAME, err).message)); 
+        } else { 
+          log('Delete:', colors.green(options.qn.origin + '/' + fileKey)); 
+        } 
+      }); 
+    }
 
     // Both stream and buffer are supported
-    client.upload(file.contents, {key: slash(fileKey)}, function(err, result) {
+    client.upload(file.contents, { key: slash(fileKey) }, function (err, result) {
       if (err) {
         log('Error', colors.red(new PluginError(PLUGIN_NAME, err).message));
       } else {


### PR DESCRIPTION
#2 
1.根据delete选项的值选择是否要先删除原来的文件再进行上传；
2.增加slashReverse参数，对路径中的斜杠进行转换。